### PR TITLE
Change route the hits script.

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -16,7 +16,7 @@ handlers:
   # This handler routes all requests not caught above to your main app. It is
   # required when static routes are defined, but can be omitted (along with
   # the entire handlers section) when there are no static files defined.
-- url: /api/.*
+- url: /api/entity-information/.*
   secure: always
   redirect_http_response_code: 301
   script: auto


### PR DESCRIPTION
Make the route to the script more specific. We found bots hitting the… /api/ route with random parameters, which needlessly invokes the script to only send a 404. It's less likely bots will hit the more specific route.