### PR TITLE
bump fastapi version to get new starlette

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 httpx==0.23.1
 gunicorn==20.1.0
 wheel==0.38.1
-fastapi==0.88.0
+fastapi==0.99.1
 uvicorn[standard]==0.20.0


### PR DESCRIPTION
This updates the versions of FastAPI (primarily to get a version of Starlet without a known vulnerability).