### PR TITLE
add a dependabot config file to allow scanning monorepo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Basic dependabot.yml file with
+# minimum configuration for two package managers
+
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `fron-end` directory
+    directory: "/front-end"
+    # Check the npm registry for updates once a week
+    schedule:
+      interval: "weekly"
+
+  # Enable version updates for Python dependencies
+  - package-ecosystem: "pip"
+    # Look for a `requirements.txt` in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This adds a config for Dependabot to allow it to find dependencies in the correct places and scan for the right type of ecosystem.