### PR TITLE
Fixed accessiblity isse with the pagination buttons

### DIFF
--- a/front-end/src/components/PageNavigation.vue
+++ b/front-end/src/components/PageNavigation.vue
@@ -99,7 +99,6 @@ const interiorIndexEnd = computed(() => {
       <li
         v-if="interiorIndexStart != 2"
         class="usa-pagination__item usa-pagination__overflow"
-        role="presentation"
         data-test="first-ellipsis"
       >
         <span>…</span>
@@ -121,7 +120,6 @@ const interiorIndexEnd = computed(() => {
       <li
         v-if="interiorIndexEnd != numberOfPages - 1"
         class="usa-pagination__item usa-pagination__overflow"
-        role="presentation"
         data-test="last-ellipsis"
       >
         <span>…</span>

--- a/front-end/src/components/PageNavigation.vue
+++ b/front-end/src/components/PageNavigation.vue
@@ -99,6 +99,7 @@ const interiorIndexEnd = computed(() => {
       <li
         v-if="interiorIndexStart != 2"
         class="usa-pagination__item usa-pagination__overflow"
+        aria-label="ellipsis indicating non-visible pages"
         data-test="first-ellipsis"
       >
         <span>…</span>
@@ -120,6 +121,7 @@ const interiorIndexEnd = computed(() => {
       <li
         v-if="interiorIndexEnd != numberOfPages - 1"
         class="usa-pagination__item usa-pagination__overflow"
+        aria-label="ellipsis indicating non-visible pages"
         data-test="last-ellipsis"
       >
         <span>…</span>


### PR DESCRIPTION
Removed role presentation from the li element containing the ellipsis. This was added to prevent screen readers from reading the li element, however violates the rule that list do not contain only li elements and script supporting elements.

Followed the uswds accessibility standard for pagination defined [here](https://designsystem.digital.gov/components/pagination/#accessibility-guidance) 