### PR TITLE
Null pointer exception Fix on search

### DIFF
--- a/samtools/sam_api/entity_information.py
+++ b/samtools/sam_api/entity_information.py
@@ -194,7 +194,10 @@ class DataAdaptors:
             return None
         if 'certifications' not in entity['repsAndCerts']:
             return None
-        return entity['repsAndCerts']['certifications'].get('fARResponses', None)
+        if entity['repsAndCerts']['certifications'] is not None:
+            return entity['repsAndCerts']['certifications'].get('fARResponses', None)
+        else:
+            return None
 
     @staticmethod
     def _get_far_52_204_26(far_responses):


### PR DESCRIPTION
Added null check on the certification section under repsAndCerts when retrieving the fARResponses.